### PR TITLE
Fix honeypot API flag and get_code usage

### DIFF
--- a/bot/honeypot.py
+++ b/bot/honeypot.py
@@ -69,7 +69,7 @@ class HoneypotChecker:
     async def _check_contract_code(self, token_address: str) -> bool:
         """Check contract bytecode for suspicious patterns"""
         try:
-            code = await self.w3.eth.get_code(token_address)
+            code = self.w3.eth.get_code(token_address)
             code_hex = code.hex()
             
             # Check for common honeypot patterns in bytecode
@@ -97,7 +97,7 @@ class HoneypotChecker:
     async def _check_honeypot_api(self, token_address: str) -> bool:
         """Check external honeypot detection APIs"""
         # Skip API check if disabled
-        if not self.config.get('USE_HONEYPOT_API', True):
+        if not getattr(self.config, 'USE_HONEYPOT_API', True):
             return False
             
         try:

--- a/bot/sniper.py
+++ b/bot/sniper.py
@@ -169,7 +169,7 @@ class SniperBot:
                 return False
                 
             # Check if contract is verified (basic check)
-            code = await self.w3.eth.get_code(token_address)
+            code = self.w3.eth.get_code(token_address)
             if len(code) <= 2:  # '0x' means no code
                 logger.warning(f"Token {token_address} has no contract code")
                 return False

--- a/tests/test_sniper.py
+++ b/tests/test_sniper.py
@@ -134,7 +134,7 @@ class TestHoneypotChecker:
         checker = HoneypotChecker(mock_w3, mock_config)
         
         # Mock contract code
-        mock_w3.eth.get_code = AsyncMock(return_value=b'0x606060')
+        mock_w3.eth.get_code = Mock(return_value=b'0x606060')
         
         result = await checker._check_contract_code("0xtokenaddress")
         assert isinstance(result, bool)


### PR DESCRIPTION
## Summary
- check USE_HONEYPOT_API flag using `getattr` instead of dict-style `get`
- remove `await` from `get_code` calls
- adjust tests for synchronous `get_code`

## Testing
- `PYTHONPATH=bot PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `npm test` *(fails: `hardhat` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462f2a2bd8832194c342e35a4070ad