### PR TITLE
Fix honeypot config attribute access

### DIFF
--- a/bot/honeypot.py
+++ b/bot/honeypot.py
@@ -97,7 +97,7 @@ class HoneypotChecker:
     async def _check_honeypot_api(self, token_address: str) -> bool:
         """Check external honeypot detection APIs"""
         # Skip API check if disabled
-        if not self.config.get('USE_HONEYPOT_API', True):
+        if not getattr(self.config, 'USE_HONEYPOT_API', True):
             return False
             
         try:


### PR DESCRIPTION
## Summary
- fix AttributeError in HoneypotChecker by using `getattr` for optional config

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=./bot PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6244f39c8321a9160c9fc7eb3065