### PR TITLE
Improve test path setup

### DIFF
--- a/bot/trading.py
+++ b/bot/trading.py
@@ -113,7 +113,3 @@ class TradingEngine:
             logger.error(f"Error in emergency sell: {e}")
             return None
 
-    def set_router_address(self, router_address: str):
-        self.router_address = (
-            router_address
-        )  # Initialize with None or appropriate default

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,11 @@
 import os
+import sys
+from pathlib import Path
 
 os.environ["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+
+# Ensure the project root is on the import path so tests work without
+# requiring PYTHONPATH to be set manually.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))


### PR DESCRIPTION
## Summary
- update test configuration to set import path
- remove an unused helper method from trading engine

## Testing
- `pytest -q`
- `npx hardhat test` *(fails: missing `hardhat-ignition` dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b8cae2acc8321a9003fa41274ef36