### PR TITLE
Fix docs and dependencies

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -11,6 +11,7 @@ from eth_typing import Address
 from eth_utils import to_checksum_address
 import json
 from pathlib import Path
+from typing import Dict, Any
 
 logger = logging.getLogger(__name__)
 

--- a/bot/honeypot.py
+++ b/bot/honeypot.py
@@ -357,3 +357,8 @@ class HoneypotDetector:
         except Exception as e:
             logger.warning(f"Verification check failed: {e}")
             return False
+
+
+class HoneypotChecker(HoneypotDetector):
+    """Backward compatibility alias for HoneypotDetector."""
+    pass

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,10 +22,7 @@ gas_price = blockchain.get_gas_price()
 from bot.trading import TradingEngine
 
 # Initialize
-trading = TradingEngine(
-    router_address="ROUTER_ADDRESS",
-    factory_address="FACTORY_ADDRESS"
-)
+trading = TradingEngine(blockchain, config)
 
 # Methods
 tx_hash = trading.buy_token(token_address, amount_eth, slippage)
@@ -37,7 +34,7 @@ position = trading.get_position(token_address)
 from bot.honeypot import HoneypotDetector
 
 # Initialize
-detector = HoneypotDetector()
+detector = HoneypotDetector(blockchain)
 
 # Methods
 is_safe = detector.analyze_token(token_address)

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ pylint==2.17.5
 types-requests==2.32.4.20250611
 types-aiofiles>=23.2.0,<24
 
-# Added from the code block
+# Dependency pin for setup tools
 setuptools<81.0.0


### PR DESCRIPTION
## Summary
- clean up requirements.txt
- update API docs to show correct initialization
- import typing in Config
- provide HoneypotChecker alias for backwards compatibility

## Testing
- `npm ci`
- `npx hardhat compile`
- `npx hardhat test`
- `pytest -q` *(fails: ImportError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b99dc79a883219bd87245035801c0